### PR TITLE
Remove org-bullets mouse stuff

### DIFF
--- a/org-bullets.el
+++ b/org-bullets.el
@@ -57,21 +57,7 @@ Otherwise the face of the heading level is used."
   :group 'org-bullets
   :type 'symbol)
 
-(defvar org-bullets-bullet-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map [mouse-1] 'org-cycle)
-    (define-key map [mouse-2] 'org-bullets-set-point-and-cycle)
-    map)
-  "Mouse events for bullets.
-Should this be undesirable, one can remove them with
-
-\(setcdr org-bullets-bullet-map nil\)")
-
-(defun org-bullets-set-point-and-cycle (event)
-  "Set `point' and where the user clicked and call `org-cycle'."
-  (interactive "e")
-  (mouse-set-point e)
-  (org-cycle))
+(defvar org-bullets-bullet-map (make-sparse-keymap))
 
 (defun org-bullets-level-char (level)
   (string-to-char


### PR DESCRIPTION
Right now org-bullets is throwing a byte-compile warning about `e` being an unused lexical variable. It turns out that the `org-bullets-set-point-and-cycle` function is broken, so this PR removes it and the associated keymap.

I decided to remove it rather than fix it because:

1. the point of org-bullets is to show bullets as UTF-8 characters, and this has nothing to do with that and 

2. Most likely no one is using it anyway, as it's been broken since
November 2017.