### PR TITLE
Honor org-odd-levels-only when computing level.

### DIFF
--- a/org-bullets.el
+++ b/org-bullets.el
@@ -61,7 +61,7 @@ Otherwise the face of the heading level is used."
 
 (defun org-bullets-level-char (level)
   (string-to-char
-   (nth (mod (1- level)
+   (nth (mod (1- (/ level (if org-odd-levels-only 2 1)))
              (length org-bullets-bullet-list))
         org-bullets-bullet-list)))
 

--- a/org-bullets.el
+++ b/org-bullets.el
@@ -61,7 +61,7 @@ Otherwise the face of the heading level is used."
 
 (defun org-bullets-level-char (level)
   (string-to-char
-   (nth (mod (1- (/ level (if org-odd-levels-only 2 1)))
+   (nth (mod (/ (1- level) (if org-odd-levels-only 2 1))
              (length org-bullets-bullet-list))
         org-bullets-bullet-list)))
 


### PR DESCRIPTION
If org-odd-levels-only is in use, the effective level is only half the apparent level, when it comes to deciding which bullet to use.  Otherwise you miss seeing half of your bullets.