### PR TITLE
Add option to make the leading stars invisible

### DIFF
--- a/org-bullets.el
+++ b/org-bullets.el
@@ -57,6 +57,17 @@ Otherwise the face of the heading level is used."
   :group 'org-bullets
   :type 'symbol)
 
+(defcustom org-bullets-invisible-leading-stars nil
+  "Invisible leading stars, instead of hidden via colour.
+Instead of making leading stars of headings have the same
+colour with background, make them disappear completely.  Useful
+if the theme used or the contents of `org-bullets-bullet-list'
+makes obvious the level of the heading.  Be aware that the
+distance of the bullets from the left edge of the window will be
+identical for all levels."
+  :group 'org-bullets
+  :type 'boolean)
+
 (defvar org-bullets-bullet-map (make-sparse-keymap))
 
 (defun org-bullets-level-char (level)
@@ -84,11 +95,15 @@ Otherwise the face of the heading level is used."
                                (- (match-end 0) 1)
                                'face
                                org-bullets-face-name))
-          (put-text-property (match-beginning 0)
-                             (- (match-end 0) 2)
-                             'face (list :foreground
-                                         (face-attribute
-                                          'default :background)))
+          (if org-bullets-invisible-leading-stars
+                      (put-text-property (match-beginning 0)
+                                         (- (match-end 0) 2)
+                                         'display '(space . (:width 0)))
+                    (put-text-property (match-beginning 0)
+                                       (- (match-end 0) 2)
+                                       'face (list :foreground
+                                                   (face-attribute
+                                                    'default :background))))
           (put-text-property (match-beginning 0)
                              (match-end 0)
                              'keymap


### PR DESCRIPTION
This PR adds the option to make the leading stars completely invisible, and not just hidden by means of color, via the variable `org-bullets-invisible-leading-stars` (`nil` by default).
In particular, when this variable is set to `t`, the headings will look like
```
x Heading level 1
o Heading level 2
> Heading level 3
o Heading level 2
```
instead of 
```
x Heading level 1
 o Heading level 2
  > Heading level 3
 o Heading level 2
```
This is useful if the contents of `org-bullets-bullet-list` make obvious the level of each heading, and thus indentation in that case is superfluous.
Note that the code of this PR originally came from [https://github.com/sabof/org-bullets/pull/13](https://github.com/sabof/org-bullets/pull/13), and, as the original PR modified a part of the minor mode definition, which was moved to  the `org-bullets--keywords` variable instead in the emacsorphanage version, a modification to move some code in its new proper place had to be done in comparison to the original PR.

P.S. I've been using a forked version of org-bullets with this code added in my own emacs config for about a month without problems, and thus thought that it would be nice if it could be added to the upstream emacsorphanage repo, so that others can benefit from it.